### PR TITLE
Fix: latestDegree isn't saved when value is set

### DIFF
--- a/Pod/Classes/CircleSlider.swift
+++ b/Pod/Classes/CircleSlider.swift
@@ -54,7 +54,7 @@ open class CircleSlider: UIControl {
       if (self._value == self.maxValue) {
          degree = degree - degree / (360 * 100)
       }
-        
+      self.latestDegree = degree
       self.layout(degree)
     }
   }


### PR DESCRIPTION
When the value property is set programatically and then the component re-renders, the slider position resets to a previous state and the UI no longer matches the value property.

The fix is to update latestDegree when the value is set explicitly.